### PR TITLE
Prompt user when leaving edit page to make sure that they want to leave.

### DIFF
--- a/app/controllers/conference/index.js
+++ b/app/controllers/conference/index.js
@@ -2,7 +2,9 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
 
+
 	editing: false,
+	navModal: false,
 
 	isInvalidTitle: false,
   	isInvalidCity: false,
@@ -58,13 +60,6 @@ export default Ember.Controller.extend({
 				meeting.rollbackAttributes();
 			});
 		},
-		unload() {
-	  		console.log('nice unload');
-			this.store.findRecord('meeting',document.getElementById('meetingId').value).then(function(meeting) {
-				meeting.rollbackAttributes();
-				meeting.set('editing',false); 
-			});
-		},
 		save() {
 			this.set('isValid',true);
 	      	this.set('isInvalidTitle', false);
@@ -108,6 +103,6 @@ export default Ember.Controller.extend({
 					meeting.save ();
 				});
 			}
-		}
+		},
 	}
 });

--- a/app/routes/conference/index.js
+++ b/app/routes/conference/index.js
@@ -1,15 +1,11 @@
 import Ember from 'ember';
 
-import ConfirmationMixin from 'ember-onbeforeunload/mixins/confirmation';
-
-export default Ember.Route.extend(ConfirmationMixin, {
-	confirmationMessage: 'Your conference may have unsaved changes. Leaving will cancel unsaved changes.',
-	//isPageDirty uses ember-onbeforeunload. onbefore unload overrides willTransition and uses onUnload() instead. Since onUnload() doesn't work, we will implement that later.
- //  	isPageDirty() { 
-	// 	var controller = this.get('controller');
-	// 	var meeting = controller.get('model.meeting'); 
-	// 	return controller.get('model.meeting.editing');
-	// },
+export default Ember.Route.extend({
+	previousTransition: null,
+	deactivate: function() {
+			var controller = this.get('controller');
+			controller.send('cancel');
+		},
 	model(params) {
         return Ember.RSVP.hash({
             meeting: this.store.find('meeting', params.id) 
@@ -21,10 +17,24 @@ export default Ember.Route.extend(ConfirmationMixin, {
         		newRoute.controller.set('visited', true);
 			});			
 		},
-		willTransition: function() {
+		willTransition: function(transition) {
+			var controller = this.get('controller');
+			if (controller.get('editing')) {
+				transition.abort();
+				controller.set('navModal',true);
+				this.set('previousTransition',transition);
+			}
+		},
+		leave() {
 			var controller = this.get('controller');
 			controller.send('cancel');
-		} 
+			controller.set('navModal',false);
+			this.get('previousTransition').retry();
+		},
+		stay() {
+			var controller = this.get('controller');
+			controller.set('navModal',false);
+		}
 	}
 });
  

--- a/app/templates/conference/index.hbs
+++ b/app/templates/conference/index.hbs
@@ -192,7 +192,14 @@
                 </div>
             </div>
             {{/if}}
-
+            {{#if this.navModal}}
+                {{#modal-dialog close="hideform" targetAttachment="center" translucentOverlay=true}}
+                    You are currently in edit mode. Changes to your meeting will not be saved.
+                    <br> Are you sure you want to leave?
+                    <br> <button class="btn btn-success"{{action "leave"}}>Yes</button> 
+                    <button class="btn btn-danger" {{action "stay"}}>No</button>
+                {{/modal-dialog}}
+            {{/if}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
When a user tries to transition out of the edit conference function, it makes sure they want to leave.

If a user tries to leave without a transition (Closing the tab, refreshing), it doesn't prompt them, but it does cancel the changes to their project. In the future we could work on making it prompt them no matter what, but this is more complicated than it sounds and not essential to the minimum viable product. This also brings up a UX debate as some users don't want to be prompted when closing out of their tabs.