### PR TITLE
Preventing blank tags from being added

### DIFF
--- a/app/controllers/conference/index/submission.js
+++ b/app/controllers/conference/index/submission.js
@@ -17,9 +17,10 @@ export default Ember.Controller.extend(TaggableMixin, {
 
  	actions: {
  		addATag(tag){
-            if (tag !== '' && tag !== undefined) {
+            if (tag !== '' && tag !== undefined && tag !== null) {
  			    this._super(tag);
             }
+            
  		},
  		displayErrors(){
  			this.set("titleError", false);


### PR DESCRIPTION
The newest version of ember-osf initializes the tag field to null so we need to check for that as well to prevent blank tags.